### PR TITLE
Improve performance of Replace function

### DIFF
--- a/src/PCRE.NET/PcreRegex.Replace.cs
+++ b/src/PCRE.NET/PcreRegex.Replace.cs
@@ -42,11 +42,13 @@ namespace PCRE
             if (count == 0)
                 return subject;
 
-            var sb = new StringBuilder((int) (subject.Length*1.2));
+            StringBuilder sb = null;
             var position = 0;
 
             foreach (var match in Matches(subject, startIndex))
             {
+                if (sb == null)
+                    sb = new StringBuilder((int)(subject.Length * 1.2));
                 sb.Append(subject, position, match.Index - position);
                 sb.Append(replacementFunc(match));
                 position = match.GetStartOfNextMatchIndex();
@@ -54,6 +56,8 @@ namespace PCRE
                 if (--count == 0)
                     break;
             }
+            if (sb == null)
+                return subject;
 
             sb.Append(subject, position, subject.Length - position);
             return sb.ToString();


### PR DESCRIPTION
Don’t allocate and Append to StringBuilder unless there is at least one match.
I discovered that using Replace repeatedly on large chunks of text with infrequent matches will generate an OutOfMemoryException due to the StringBuilder allocations, most of which are not needed. This commit fixes that.