### PR TITLE
Support for ReadOnlySpan<char> inputs

### DIFF
--- a/src/PCRE.NET.Tests/Pcre/TestCase.cs
+++ b/src/PCRE.NET.Tests/Pcre/TestCase.cs
@@ -1,17 +1,12 @@
-﻿using System.Collections.Generic;
-
 namespace PCRE.Tests.Pcre
 {
     public class TestCase
     {
-        public TestPattern Pattern { get; set; }
-        public IList<string> SubjectLines { get; }
+        public TestInput Input { get; set; }
+        public TestOutput ExpectedResult { get; set; }
 
-        public TestCase()
-        {
-            SubjectLines = new List<string>();
-        }
+        public bool Jit { get; set; }
 
-        public override string ToString() => Pattern?.ToString() ?? "???";
+        public override string ToString() => Input.ToString();
     }
 }

--- a/src/PCRE.NET.Tests/Pcre/TestCase.cs
+++ b/src/PCRE.NET.Tests/Pcre/TestCase.cs
@@ -2,10 +2,13 @@ namespace PCRE.Tests.Pcre
 {
     public class TestCase
     {
+        public string TestFile { get; set; }
+
         public TestInput Input { get; set; }
         public TestOutput ExpectedResult { get; set; }
 
         public bool Jit { get; set; }
+        public bool Span { get; set; }
 
         public override string ToString() => Input.ToString();
     }

--- a/src/PCRE.NET.Tests/Pcre/TestInput.cs
+++ b/src/PCRE.NET.Tests/Pcre/TestInput.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace PCRE.Tests.Pcre
+{
+    public class TestInput
+    {
+        public TestPattern Pattern { get; set; }
+        public IList<string> SubjectLines { get; }
+
+        public TestInput()
+        {
+            SubjectLines = new List<string>();
+        }
+
+        public override string ToString() => Pattern?.ToString() ?? "???";
+    }
+}

--- a/src/PCRE.NET.Tests/Pcre/TestInputReader.cs
+++ b/src/PCRE.NET.Tests/Pcre/TestInputReader.cs
@@ -10,7 +10,7 @@ namespace PCRE.Tests.Pcre
         {
         }
 
-        public IEnumerable<TestCase> ReadTestCases()
+        public IEnumerable<TestInput> ReadTestInputs()
         {
             while (true)
             {
@@ -19,7 +19,7 @@ namespace PCRE.Tests.Pcre
                 if (pattern == null)
                     yield break;
 
-                var testCase = new TestCase
+                var testCase = new TestInput
                 {
                     Pattern = pattern,
                 };

--- a/src/PCRE.NET.Tests/PcreNet/IsMatchTests.cs
+++ b/src/PCRE.NET.Tests/PcreNet/IsMatchTests.cs
@@ -44,7 +44,9 @@ namespace PCRE.Tests.PcreNet
         public void should_match_pattern(string pattern, string subject)
         {
             Assert.That(new PcreRegex(pattern).IsMatch(subject), Is.True);
+            Assert.That(new PcreRegex(pattern).IsMatch(subject.AsSpan()), Is.True);
             Assert.That(new PcreRegex(pattern, PcreOptions.Compiled).IsMatch(subject), Is.True);
+            Assert.That(new PcreRegex(pattern, PcreOptions.Compiled).IsMatch(subject.AsSpan()), Is.True);
         }
 
         [Test]
@@ -53,7 +55,9 @@ namespace PCRE.Tests.PcreNet
         public void should_not_match_pattern(string pattern, string subject)
         {
             Assert.That(new PcreRegex(pattern).IsMatch(subject), Is.False);
+            Assert.That(new PcreRegex(pattern).IsMatch(subject.AsSpan()), Is.False);
             Assert.That(new PcreRegex(pattern, PcreOptions.Compiled).IsMatch(subject), Is.False);
+            Assert.That(new PcreRegex(pattern, PcreOptions.Compiled).IsMatch(subject.AsSpan()), Is.False);
         }
 
         [Test]
@@ -61,9 +65,11 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex("aBc");
             Assert.That(re.IsMatch("Abc"), Is.False);
+            Assert.That(re.IsMatch("Abc".AsSpan()), Is.False);
 
             re = new PcreRegex("aBc", PcreOptions.IgnoreCase);
             Assert.That(re.IsMatch("Abc"), Is.True);
+            Assert.That(re.IsMatch("Abc".AsSpan()), Is.True);
         }
 
         [Test]
@@ -71,9 +77,11 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex("^a b$");
             Assert.That(re.IsMatch("ab"), Is.False);
+            Assert.That(re.IsMatch("ab".AsSpan()), Is.False);
 
             re = new PcreRegex("^a b$", PcreOptions.IgnorePatternWhitespace);
             Assert.That(re.IsMatch("ab"), Is.True);
+            Assert.That(re.IsMatch("ab".AsSpan()), Is.True);
         }
 
         [Test]
@@ -81,9 +89,11 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex("^a.*b$");
             Assert.That(re.IsMatch("a\r\nb"), Is.False);
+            Assert.That(re.IsMatch("a\r\nb".AsSpan()), Is.False);
 
             re = new PcreRegex("^a.*b$", PcreOptions.Singleline);
             Assert.That(re.IsMatch("a\r\nb"), Is.True);
+            Assert.That(re.IsMatch("a\r\nb".AsSpan()), Is.True);
         }
 
         [Test]
@@ -91,9 +101,11 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex("^aaa$");
             Assert.That(re.IsMatch("aaa\r\nbbb"), Is.False);
+            Assert.That(re.IsMatch("aaa\r\nbbb".AsSpan()), Is.False);
 
             re = new PcreRegex("^aaa$", PcreOptions.MultiLine);
             Assert.That(re.IsMatch("aaa\r\nbbb"), Is.True);
+            Assert.That(re.IsMatch("aaa\r\nbbb".AsSpan()), Is.True);
         }
 
         [Test]
@@ -101,6 +113,7 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex(@"^\U$", PcreOptions.JavaScript);
             Assert.That(re.IsMatch("U"), Is.True);
+            Assert.That(re.IsMatch("U".AsSpan()), Is.True);
 
             // ReSharper disable once ObjectCreationAsStatement
             Assert.Throws<ArgumentException>(() => new PcreRegex(@"^\U$"));
@@ -111,9 +124,11 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex(@"^\w$");
             Assert.That(re.IsMatch("à"), Is.False);
+            Assert.That(re.IsMatch("à".AsSpan()), Is.False);
 
             re = new PcreRegex(@"^\w$", PcreOptions.Unicode);
             Assert.That(re.IsMatch("à"), Is.True);
+            Assert.That(re.IsMatch("à".AsSpan()), Is.True);
         }
 
         [Test]
@@ -121,6 +136,7 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex(@"a");
             Assert.That(re.IsMatch("foobar", 5), Is.False);
+            Assert.That(re.IsMatch("foobar".AsSpan(), 5), Is.False);
         }
 
         [Test]
@@ -128,6 +144,7 @@ namespace PCRE.Tests.PcreNet
         {
             var re = new PcreRegex(@"(?<=a)");
             Assert.That(re.IsMatch("xxa", 3), Is.True);
+            Assert.That(re.IsMatch("xxa".AsSpan(), 3), Is.True);
         }
     }
 }

--- a/src/PCRE.NET.Tests/PcreNet/MatchTests.cs
+++ b/src/PCRE.NET.Tests/PcreNet/MatchTests.cs
@@ -262,6 +262,24 @@ namespace PCRE.Tests.PcreNet
         }
 
         [Test]
+        public void should_allow_duplicate_names_ref()
+        {
+            var re = new PcreRegex(@"(?<g>a)?(?<g>b)?(?<g>c)?", PcreOptions.DupNames);
+            var match = re.Match("b".AsSpan());
+
+            Assert.That(match.Success, Is.True);
+            Assert.That(match["g"].Value.ToString(), Is.EqualTo("b"));
+
+            Assert.That(GetDuplicateNamedGroupsSuccesses(match, "g"), Is.EqualTo(new[] { false, true, false }));
+
+            match = re.Match("bc".AsSpan());
+            Assert.That(match.Success, Is.True);
+            Assert.That(match["g"].Value.ToString(), Is.EqualTo("b"));
+
+            Assert.That(GetDuplicateNamedGroupsSuccesses(match, "g"), Is.EqualTo(new[] { false, true, true }));
+        }
+
+        [Test]
         public void should_detect_duplicate_names()
         {
             var re = new PcreRegex(@"(?J)(?<g>a)?(?<g>b)?(?<g>c)?");
@@ -272,6 +290,28 @@ namespace PCRE.Tests.PcreNet
             Assert.That(match["g"].Value, Is.EqualTo("b"));
 
             Assert.That(match.GetDuplicateNamedGroups("g").Select(g => g.Success), Is.EqualTo(new[] { false, true, true }));
+        }
+
+        [Test]
+        public void should_detect_duplicate_names_ref()
+        {
+            var re = new PcreRegex(@"(?J)(?<g>a)?(?<g>b)?(?<g>c)?");
+
+            var match = re.Match("bc".AsSpan());
+            Assert.That(match.Success, Is.True);
+            Assert.That(match["g"].Value.ToString(), Is.EqualTo("b"));
+
+            Assert.That(GetDuplicateNamedGroupsSuccesses(match, "g"), Is.EqualTo(new[] { false, true, true }));
+        }
+
+        private static List<bool> GetDuplicateNamedGroupsSuccesses(PcreRefMatch match, string groupName)
+        {
+            var result = new List<bool>();
+
+            foreach (var group in match.GetDuplicateNamedGroups(groupName))
+                result.Add(group.Success);
+
+            return result;
         }
 
         [Test]

--- a/src/PCRE.NET.Tests/PcreNet/MatchTests.cs
+++ b/src/PCRE.NET.Tests/PcreNet/MatchTests.cs
@@ -320,6 +320,21 @@ namespace PCRE.Tests.PcreNet
         }
 
         [Test]
+        public void should_use_callout_result_ref()
+        {
+            var regex = new PcreRegex(@"(\d+)(*SKIP)(?C1):\s*(\w+)");
+
+            var match = regex.Match(
+                "1542: not_this, 1764: hello".AsSpan(),
+                data => data.Number == 1
+                        && int.Parse(data.Match[1].Value.ToString()) % 42 == 0
+                    ? PcreCalloutResult.Pass
+                    : PcreCalloutResult.Fail);
+
+            Assert.That(match[2].Value.ToString(), Is.EqualTo("hello"));
+        }
+
+        [Test]
         public void should_execute_passing_callout()
         {
             const string pattern = @"(a)(*MARK:foo)(x)?(?C42)(bc)";
@@ -358,6 +373,43 @@ namespace PCRE.Tests.PcreNet
         }
 
         [Test]
+        public void should_execute_passing_callout_ref()
+        {
+            const string pattern = @"(a)(*MARK:foo)(x)?(?C42)(bc)";
+            var re = new PcreRegex(pattern);
+
+            var calls = 0;
+
+            var match = re.Match("abc".AsSpan(), data =>
+            {
+                Assert.That(data.Number, Is.EqualTo(42));
+                Assert.That(data.CurrentOffset, Is.EqualTo(1));
+                Assert.That(data.PatternPosition, Is.EqualTo(pattern.IndexOf("(?C42)", StringComparison.Ordinal) + 6));
+                Assert.That(data.StartOffset, Is.EqualTo(0));
+                Assert.That(data.LastCapture, Is.EqualTo(1));
+                Assert.That(data.MaxCapture, Is.EqualTo(2));
+                Assert.That(data.NextPatternItemLength, Is.EqualTo(1));
+                Assert.That(data.StringOffset, Is.EqualTo(0));
+                Assert.That(data.String, Is.Null);
+
+                Assert.That(data.Match.Value.ToString(), Is.EqualTo("a"));
+                Assert.That(data.Match[1].Value.ToString(), Is.EqualTo("a"));
+                Assert.That(data.Match[2].Success, Is.False);
+                Assert.That(data.Match[2].Value.ToString(), Is.SameAs(string.Empty));
+                Assert.That(data.Match[3].Success, Is.False);
+                Assert.That(data.Match[3].Value.ToString(), Is.SameAs(string.Empty));
+
+                Assert.That(data.Match.Mark.ToString(), Is.EqualTo("foo"));
+
+                ++calls;
+                return PcreCalloutResult.Pass;
+            });
+
+            Assert.That(match.Success, Is.True);
+            Assert.That(calls, Is.EqualTo(1));
+        }
+
+        [Test]
         public void should_execute_failing_callout()
         {
             var re = new PcreRegex(@".(?C42)");
@@ -382,6 +434,29 @@ namespace PCRE.Tests.PcreNet
         }
 
         [Test]
+        public void should_execute_failing_callout_ref()
+        {
+            var re = new PcreRegex(@".(?C42)");
+
+            var first = true;
+
+            var match = re.Match("ab".AsSpan(), data =>
+            {
+                Assert.That(data.Number, Is.EqualTo(42));
+                if (first)
+                {
+                    first = false;
+                    return PcreCalloutResult.Fail;
+                }
+
+                return PcreCalloutResult.Pass;
+            });
+
+            Assert.That(match.Success, Is.True);
+            Assert.That(match.Value.ToString(), Is.EqualTo("b"));
+        }
+
+        [Test]
         public void should_execute_aborting_callout()
         {
             var re = new PcreRegex(@".(?C42)");
@@ -397,11 +472,35 @@ namespace PCRE.Tests.PcreNet
         }
 
         [Test]
+        public void should_execute_aborting_callout_ref()
+        {
+            var re = new PcreRegex(@".(?C42)");
+
+            var match = re.Match("ab".AsSpan(), data =>
+            {
+                Assert.That(data.Number, Is.EqualTo(42));
+                return PcreCalloutResult.Abort;
+            });
+
+            Assert.That(match.Success, Is.False);
+        }
+
+        [Test]
         public void should_throw_when_callout_throws()
         {
             var re = new PcreRegex(@".(?C42)");
 
             var ex = Assert.Throws<PcreCalloutException>(() => re.Match("ab", data => { throw new DivideByZeroException("test"); }));
+
+            Assert.That(ex.InnerException, Is.InstanceOf<DivideByZeroException>());
+        }
+
+        [Test]
+        public void should_throw_when_callout_throws_ref()
+        {
+            var re = new PcreRegex(@".(?C42)");
+
+            var ex = Assert.Throws<PcreCalloutException>(() => re.Match("ab".AsSpan(), data => { throw new DivideByZeroException("test"); }));
 
             Assert.That(ex.InnerException, Is.InstanceOf<DivideByZeroException>());
         }
@@ -426,6 +525,24 @@ namespace PCRE.Tests.PcreNet
         }
 
         [Test]
+        public void should_auto_callout_ref()
+        {
+            var re = new PcreRegex(@"a.c", PcreOptions.AutoCallout);
+
+            var count = 0;
+
+            var match = re.Match("abc".AsSpan(), data =>
+            {
+                Assert.That(data.Number, Is.EqualTo(255));
+                ++count;
+                return PcreCalloutResult.Pass;
+            });
+
+            Assert.That(match.Success, Is.True);
+            Assert.That(count, Is.EqualTo(4));
+        }
+
+        [Test]
         public void should_provide_callout_flags()
         {
             var re = new PcreRegex(@"a(?C1)(?:(?C2)(*FAIL)|b)(?C3)");
@@ -434,6 +551,25 @@ namespace PCRE.Tests.PcreNet
             var backtrackList = new List<bool>();
 
             re.Match("abc", data =>
+            {
+                startMatchList.Add(data.StartMatch);
+                backtrackList.Add(data.Backtrack);
+                return PcreCalloutResult.Pass;
+            });
+
+            Assert.That(startMatchList, Is.EqualTo(new[] { true, false, false }));
+            Assert.That(backtrackList, Is.EqualTo(new[] { false, false, true }));
+        }
+
+        [Test]
+        public void should_provide_callout_flags_ref()
+        {
+            var re = new PcreRegex(@"a(?C1)(?:(?C2)(*FAIL)|b)(?C3)");
+
+            var startMatchList = new List<bool>();
+            var backtrackList = new List<bool>();
+
+            re.Match("abc".AsSpan(), data =>
             {
                 startMatchList.Add(data.StartMatch);
                 backtrackList.Add(data.Backtrack);
@@ -478,6 +614,43 @@ namespace PCRE.Tests.PcreNet
             });
 
             Assert.That(match, Is.Not.Null);
+            Assert.That(match.Success, Is.True);
+            Assert.That(calls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void should_execute_string_callout_ref()
+        {
+            const string pattern = @"(a)(*MARK:foo)(x)?(?C{bar})(bc)";
+            var re = new PcreRegex(pattern);
+
+            var calls = 0;
+
+            var match = re.Match("abc".AsSpan(), data =>
+            {
+                Assert.That(data.Number, Is.EqualTo(0));
+                Assert.That(data.CurrentOffset, Is.EqualTo(1));
+                Assert.That(data.PatternPosition, Is.EqualTo(pattern.IndexOf("(?C{bar})", StringComparison.Ordinal) + 9));
+                Assert.That(data.StartOffset, Is.EqualTo(0));
+                Assert.That(data.LastCapture, Is.EqualTo(1));
+                Assert.That(data.MaxCapture, Is.EqualTo(2));
+                Assert.That(data.NextPatternItemLength, Is.EqualTo(1));
+                Assert.That(data.StringOffset, Is.EqualTo(pattern.IndexOf("(?C{bar})", StringComparison.Ordinal) + 4));
+                Assert.That(data.String, Is.EqualTo("bar"));
+
+                Assert.That(data.Match.Value.ToString(), Is.EqualTo("a"));
+                Assert.That(data.Match[1].Value.ToString(), Is.EqualTo("a"));
+                Assert.That(data.Match[2].Success, Is.False);
+                Assert.That(data.Match[2].Value.ToString(), Is.SameAs(string.Empty));
+                Assert.That(data.Match[3].Success, Is.False);
+                Assert.That(data.Match[3].Value.ToString(), Is.SameAs(string.Empty));
+
+                Assert.That(data.Match.Mark.ToString(), Is.EqualTo("foo"));
+
+                ++calls;
+                return PcreCalloutResult.Pass;
+            });
+
             Assert.That(match.Success, Is.True);
             Assert.That(calls, Is.EqualTo(1));
         }

--- a/src/PCRE.NET/Internal/CalloutInterop.cs
+++ b/src/PCRE.NET/Internal/CalloutInterop.cs
@@ -9,36 +9,35 @@ namespace PCRE.Internal
     internal static unsafe class CalloutInterop
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate int CalloutHandlerFunc(ref Native.pcre2_callout_block callout, void* data);
+        private delegate int CalloutHandlerFunc(Native.pcre2_callout_block* callout, void* data);
 
         private static readonly CalloutHandlerFunc _calloutHandlerDelegate = CalloutHandler; // GC root
         private static readonly void* _calloutHandlerFnPtr = Marshal.GetFunctionPointerForDelegate(_calloutHandlerDelegate).ToPointer();
 
-        private static int CalloutHandler(ref Native.pcre2_callout_block callout, void* data)
-        {
-            ref var interopInfo = ref ToInteropInfo(data);
-
-            try
-            {
-                return (int)interopInfo.Callout(new PcreCallout(interopInfo.Subject, interopInfo.Regex, ref callout));
-            }
-            catch (Exception ex)
-            {
-                interopInfo.Exception = ex;
-                return PcreConstants.ERROR_CALLOUT;
-            }
-        }
+        private static int CalloutHandler(Native.pcre2_callout_block* callout, void* data)
+            => ToInteropInfo(data).Call(callout);
 
         public static void Prepare(string subject, InternalRegex regex, ref Native.match_input input, out CalloutInteropInfo interopInfo, Func<PcreCallout, PcreCalloutResult> callout)
         {
             if (callout != null)
             {
-                interopInfo = new CalloutInteropInfo
-                {
-                    Subject = subject,
-                    Regex = regex,
-                    Callout = callout
-                };
+                interopInfo = new CalloutInteropInfo(subject, regex, callout);
+
+                input.callout = _calloutHandlerFnPtr;
+                input.callout_data = interopInfo.ToPointer();
+            }
+            else
+            {
+                interopInfo = default;
+                input.callout = null;
+            }
+        }
+
+        public static void Prepare(ReadOnlySpan<char> subject, InternalRegex regex, ref Native.match_input input, out CalloutInteropInfo interopInfo, PcreRefCalloutFunc callout)
+        {
+            if (callout != null)
+            {
+                interopInfo = new CalloutInteropInfo(subject, regex, callout);
 
                 input.callout = _calloutHandlerFnPtr;
                 input.callout_data = interopInfo.ToPointer();
@@ -54,12 +53,7 @@ namespace PCRE.Internal
         {
             if (callout != null)
             {
-                interopInfo = new CalloutInteropInfo
-                {
-                    Subject = subject,
-                    Regex = regex,
-                    Callout = callout
-                };
+                interopInfo = new CalloutInteropInfo(subject, regex, callout);
 
                 input.callout = _calloutHandlerFnPtr;
                 input.callout_data = interopInfo.ToPointer();
@@ -97,10 +91,51 @@ namespace PCRE.Internal
 
         public ref struct CalloutInteropInfo
         {
-            public string Subject;
-            public InternalRegex Regex;
-            public Func<PcreCallout, PcreCalloutResult> Callout;
-            public Exception Exception;
+            private readonly string _subject;
+            private readonly ReadOnlySpan<char> _subjectSpan;
+            private readonly InternalRegex _regex;
+            private readonly Delegate _callout;
+            public Exception Exception { get; private set; }
+
+            public CalloutInteropInfo(string subject, InternalRegex regex, Func<PcreCallout, PcreCalloutResult> callout)
+            {
+                _subject = subject;
+                _subjectSpan = default;
+                _regex = regex;
+                _callout = callout;
+                Exception = null;
+            }
+
+            public CalloutInteropInfo(ReadOnlySpan<char> subject, InternalRegex regex, PcreRefCalloutFunc callout)
+            {
+                _subject = null;
+                _subjectSpan = subject;
+                _regex = regex;
+                _callout = callout;
+                Exception = null;
+            }
+
+            public int Call(Native.pcre2_callout_block* callout)
+            {
+                try
+                {
+                    if (_subject != null)
+                    {
+                        var func = (Func<PcreCallout, PcreCalloutResult>)_callout;
+                        return (int)func(new PcreCallout(_subject, _regex, callout));
+                    }
+                    else
+                    {
+                        var func = (PcreRefCalloutFunc)_callout;
+                        return (int)func(new PcreRefCallout(_subjectSpan, _regex, callout));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Exception = ex;
+                    return PcreConstants.ERROR_CALLOUT;
+                }
+            }
         }
     }
 }

--- a/src/PCRE.NET/Internal/InternalRegex.cs
+++ b/src/PCRE.NET/Internal/InternalRegex.cs
@@ -113,7 +113,7 @@ namespace PCRE.Internal
             var input = new Native.match_input();
             settings.FillMatchInput(ref input);
 
-            var oVector = new uint[2 * (CaptureCount + 1)];
+            var oVector = CreateNfaOVector();
             Native.match_result result;
             CalloutInterop.CalloutInteropInfo calloutInterop;
 
@@ -137,25 +137,7 @@ namespace PCRE.Internal
             return new PcreMatch(subject, this, ref result, oVector);
         }
 
-        public PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchSettings settings, int startIndex, uint additionalOptions)
-            => Match(
-                subject,
-                settings,
-                new uint[2 * (CaptureCount + 1)],
-                startIndex,
-                additionalOptions
-            );
-
-        public PcreRefMatch NextMatch(in PcreRefMatch match, PcreMatchSettings settings, int startIndex, uint additionalOptions)
-            => Match(
-                match.Subject,
-                settings,
-                match.OVector,
-                startIndex,
-                additionalOptions
-            );
-
-        private PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchSettings settings, uint[] oVector, int startIndex, uint additionalOptions)
+        public PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchSettings settings, uint[] oVector, int startIndex, uint additionalOptions)
         {
             var input = new Native.match_input();
             settings.FillMatchInput(ref input);
@@ -233,6 +215,9 @@ namespace PCRE.Internal
                     break;
             }
         }
+
+        public uint[] CreateNfaOVector()
+            => new uint[2 * (CaptureCount + 1)];
 
         public IReadOnlyList<PcreCalloutInfo> GetCallouts()
         {

--- a/src/PCRE.NET/Internal/InternalRegex.cs
+++ b/src/PCRE.NET/Internal/InternalRegex.cs
@@ -156,6 +156,9 @@ namespace PCRE.Internal
                 input.start_index = (uint)startIndex;
                 input.additional_options = additionalOptions;
 
+                if (input.subject == (char*)0 && input.subject_length == 0)
+                    input.subject = (char*)1; // PCRE doesn't like null subjects, even if the length is zero
+
                 CalloutInterop.Prepare(subject, this, ref input, out calloutInterop, settings.RefCallout);
 
                 Native.match(ref input, out result);

--- a/src/PCRE.NET/Internal/InternalRegex.cs
+++ b/src/PCRE.NET/Internal/InternalRegex.cs
@@ -156,9 +156,7 @@ namespace PCRE.Internal
                 input.start_index = (uint)startIndex;
                 input.additional_options = additionalOptions;
 
-                // TODO callouts
-                //CalloutInterop.Prepare(subject, this, ref input, out calloutInterop, settings.Callout);
-                calloutInterop = default;
+                CalloutInterop.Prepare(subject, this, ref input, out calloutInterop, settings.RefCallout);
 
                 Native.match(ref input, out result);
             }

--- a/src/PCRE.NET/Internal/InternalRegex.cs
+++ b/src/PCRE.NET/Internal/InternalRegex.cs
@@ -138,11 +138,28 @@ namespace PCRE.Internal
         }
 
         public PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchSettings settings, int startIndex, uint additionalOptions)
+            => Match(
+                subject,
+                settings,
+                new uint[2 * (CaptureCount + 1)],
+                startIndex,
+                additionalOptions
+            );
+
+        public PcreRefMatch NextMatch(in PcreRefMatch match, PcreMatchSettings settings, int startIndex, uint additionalOptions)
+            => Match(
+                match.Subject,
+                settings,
+                match.OVector,
+                startIndex,
+                additionalOptions
+            );
+
+        private PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchSettings settings, uint[] oVector, int startIndex, uint additionalOptions)
         {
             var input = new Native.match_input();
             settings.FillMatchInput(ref input);
 
-            var oVector = new uint[2 * (CaptureCount + 1)];
             Native.match_result result;
             CalloutInterop.CalloutInteropInfo calloutInterop;
 

--- a/src/PCRE.NET/PCRE.NET.csproj
+++ b/src/PCRE.NET/PCRE.NET.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.0.5" PrivateAssets="all" />
     <PackageReference Include="InlineIL.Fody" Version="1.3.4" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PCRE.NET/PcreCallout.cs
+++ b/src/PCRE.NET/PcreCallout.cs
@@ -12,27 +12,27 @@ namespace PCRE
         private PcreMatch _match;
         private PcreCalloutInfo _info;
 
-        internal PcreCallout(string subject, InternalRegex regex, ref Native.pcre2_callout_block callout)
+        internal PcreCallout(string subject, InternalRegex regex, Native.pcre2_callout_block* callout)
         {
             _subject = subject;
             _regex = regex;
-            _flags = callout.callout_flags;
+            _flags = callout->callout_flags;
 
-            Number = (int)callout.callout_number;
-            StartOffset = (int)callout.start_match;
-            CurrentOffset = (int)callout.current_position;
-            MaxCapture = (int)callout.capture_top;
-            LastCapture = (int)callout.capture_last;
-            PatternPosition = (int)callout.pattern_position;
-            NextPatternItemLength = (int)callout.next_item_length;
-            _markPtr = callout.mark;
+            Number = (int)callout->callout_number;
+            StartOffset = (int)callout->start_match;
+            CurrentOffset = (int)callout->current_position;
+            MaxCapture = (int)callout->capture_top;
+            LastCapture = (int)callout->capture_last;
+            PatternPosition = (int)callout->pattern_position;
+            NextPatternItemLength = (int)callout->next_item_length;
+            _markPtr = callout->mark;
 
-            _oVector = new uint[callout.capture_top * 2];
-            _oVector[0] = (uint)callout.start_match;
-            _oVector[1] = (uint)callout.current_position;
+            _oVector = new uint[callout->capture_top * 2];
+            _oVector[0] = (uint)callout->start_match;
+            _oVector[1] = (uint)callout->current_position;
 
             for (var i = 2; i < _oVector.Length; ++i)
-                _oVector[i] = callout.offset_vector[i].ToUInt32();
+                _oVector[i] = callout->offset_vector[i].ToUInt32();
         }
 
         public int Number { get; }

--- a/src/PCRE.NET/PcreMatchSettings.cs
+++ b/src/PCRE.NET/PcreMatchSettings.cs
@@ -6,7 +6,7 @@ namespace PCRE
 {
     public sealed class PcreMatchSettings
     {
-        private static readonly PcreMatchSettings _defaultSettings = new PcreMatchSettings();
+        internal static PcreMatchSettings Default { get; } = new PcreMatchSettings();
 
         private uint? _matchLimit;
         private uint? _depthLimit;
@@ -49,7 +49,7 @@ namespace PCRE
         internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, Func<PcreCallout, PcreCalloutResult> onCallout)
         {
             if (startIndex == 0 && additionalOptions == PcreMatchOptions.None && onCallout == null)
-                return _defaultSettings;
+                return Default;
 
             var settings = new PcreMatchSettings
             {

--- a/src/PCRE.NET/PcreMatchSettings.cs
+++ b/src/PCRE.NET/PcreMatchSettings.cs
@@ -15,20 +15,6 @@ namespace PCRE
         public PcreMatchOptions AdditionalOptions { get; set; }
         public int StartIndex { get; set; }
 
-        [SuppressMessage("ReSharper", "DelegateSubtraction")]
-        public event Func<PcreCallout, PcreCalloutResult> OnCallout
-        {
-            add => Callout += value;
-            remove => Callout -= value;
-        }
-
-        [SuppressMessage("ReSharper", "DelegateSubtraction")]
-        public event PcreRefCalloutFunc OnRefCallout
-        {
-            add => RefCallout += value;
-            remove => RefCallout -= value;
-        }
-
         public uint MatchLimit
         {
             get => _matchLimit ?? PcreBuildInfo.MatchLimit;
@@ -54,9 +40,21 @@ namespace PCRE
         internal Func<PcreCallout, PcreCalloutResult> Callout { get; private set; }
         internal PcreRefCalloutFunc RefCallout { get; private set; }
 
-        internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, Func<PcreCallout, PcreCalloutResult> onCallout)
+        public void SetCallout(Func<PcreCallout, PcreCalloutResult> callout)
         {
-            if (startIndex == 0 && additionalOptions == PcreMatchOptions.None && onCallout == null)
+            Callout = callout;
+            RefCallout = null;
+        }
+
+        public void SetCallout(PcreRefCalloutFunc callout)
+        {
+            Callout = null;
+            RefCallout = callout;
+        }
+
+        internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, Func<PcreCallout, PcreCalloutResult> callout)
+        {
+            if (startIndex == 0 && additionalOptions == PcreMatchOptions.None && callout == null)
                 return Default;
 
             var settings = new PcreMatchSettings
@@ -65,15 +63,14 @@ namespace PCRE
                 AdditionalOptions = additionalOptions
             };
 
-            if (onCallout != null)
-                settings.OnCallout += onCallout;
+            settings.SetCallout(callout);
 
             return settings;
         }
 
-        internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, PcreRefCalloutFunc onCallout)
+        internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, PcreRefCalloutFunc callout)
         {
-            if (startIndex == 0 && additionalOptions == PcreMatchOptions.None && onCallout == null)
+            if (startIndex == 0 && additionalOptions == PcreMatchOptions.None && callout == null)
                 return Default;
 
             var settings = new PcreMatchSettings
@@ -82,8 +79,7 @@ namespace PCRE
                 AdditionalOptions = additionalOptions
             };
 
-            if (onCallout != null)
-                settings.OnRefCallout += onCallout;
+            settings.SetCallout(callout);
 
             return settings;
         }

--- a/src/PCRE.NET/PcreMatchSettings.cs
+++ b/src/PCRE.NET/PcreMatchSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using PCRE.Internal;
 
 namespace PCRE

--- a/src/PCRE.NET/PcreMatchSettings.cs
+++ b/src/PCRE.NET/PcreMatchSettings.cs
@@ -22,6 +22,13 @@ namespace PCRE
             remove => Callout -= value;
         }
 
+        [SuppressMessage("ReSharper", "DelegateSubtraction")]
+        public event PcreRefCalloutFunc OnRefCallout
+        {
+            add => RefCallout += value;
+            remove => RefCallout -= value;
+        }
+
         public uint MatchLimit
         {
             get => _matchLimit ?? PcreBuildInfo.MatchLimit;
@@ -45,6 +52,7 @@ namespace PCRE
         public PcreJitStack JitStack { get; set; }
 
         internal Func<PcreCallout, PcreCalloutResult> Callout { get; private set; }
+        internal PcreRefCalloutFunc RefCallout { get; private set; }
 
         internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, Func<PcreCallout, PcreCalloutResult> onCallout)
         {
@@ -59,6 +67,23 @@ namespace PCRE
 
             if (onCallout != null)
                 settings.OnCallout += onCallout;
+
+            return settings;
+        }
+
+        internal static PcreMatchSettings GetSettings(int startIndex, PcreMatchOptions additionalOptions, PcreRefCalloutFunc onCallout)
+        {
+            if (startIndex == 0 && additionalOptions == PcreMatchOptions.None && onCallout == null)
+                return Default;
+
+            var settings = new PcreMatchSettings
+            {
+                StartIndex = startIndex,
+                AdditionalOptions = additionalOptions
+            };
+
+            if (onCallout != null)
+                settings.OnRefCallout += onCallout;
 
             return settings;
         }

--- a/src/PCRE.NET/PcreRefCallout.cs
+++ b/src/PCRE.NET/PcreRefCallout.cs
@@ -1,0 +1,62 @@
+using System;
+using PCRE.Internal;
+
+namespace PCRE
+{
+    public delegate PcreCalloutResult PcreRefCalloutFunc(PcreRefCallout callout);
+
+    public unsafe ref struct PcreRefCallout
+    {
+        private readonly ReadOnlySpan<char> _subject;
+        private readonly InternalRegex _regex;
+        private readonly Native.pcre2_callout_block* _callout;
+
+        private uint[] _oVector;
+        private PcreCalloutInfo _info;
+
+        internal PcreRefCallout(ReadOnlySpan<char> subject, InternalRegex regex, Native.pcre2_callout_block* callout)
+        {
+            _subject = subject;
+            _regex = regex;
+            _callout = callout;
+
+            _oVector = null;
+            _info = null;
+        }
+
+        public int Number => (int)_callout->callout_number;
+
+        public PcreRefMatch Match
+        {
+            get
+            {
+                if (_oVector == null)
+                {
+                    _oVector = new uint[_callout->capture_top * 2];
+                    _oVector[0] = (uint)_callout->start_match;
+                    _oVector[1] = (uint)_callout->current_position;
+
+                    for (var i = 2; i < _oVector.Length; ++i)
+                        _oVector[i] = _callout->offset_vector[i].ToUInt32();
+                }
+
+                return new PcreRefMatch(_subject, _regex, _oVector, _callout->mark);
+            }
+        }
+
+        public int StartOffset => (int)_callout->start_match;
+        public int CurrentOffset => (int)_callout->current_position;
+        public int MaxCapture => (int)_callout->capture_top;
+        public int LastCapture => (int)_callout->capture_last;
+        public int PatternPosition => (int)_callout->pattern_position;
+
+        public int NextPatternItemLength => (int)_callout->next_item_length;
+        public int StringOffset => Info.StringOffset;
+        public string String => Info.String;
+
+        public PcreCalloutInfo Info => _info ??= _regex.GetCalloutInfoByPatternPosition(PatternPosition);
+
+        public bool StartMatch => (_callout->callout_flags & PcreConstants.CALLOUT_STARTMATCH) != 0;
+        public bool Backtrack => (_callout->callout_flags & PcreConstants.CALLOUT_BACKTRACK) != 0;
+    }
+}

--- a/src/PCRE.NET/PcreRefCallout.cs
+++ b/src/PCRE.NET/PcreRefCallout.cs
@@ -12,7 +12,6 @@ namespace PCRE
         private readonly Native.pcre2_callout_block* _callout;
 
         private uint[] _oVector;
-        private PcreCalloutInfo _info;
 
         internal PcreRefCallout(ReadOnlySpan<char> subject, InternalRegex regex, Native.pcre2_callout_block* callout)
         {
@@ -21,10 +20,9 @@ namespace PCRE
             _callout = callout;
 
             _oVector = null;
-            _info = null;
         }
 
-        public int Number => (int)_callout->callout_number;
+        public readonly int Number => (int)_callout->callout_number;
 
         public PcreRefMatch Match
         {
@@ -44,19 +42,19 @@ namespace PCRE
             }
         }
 
-        public int StartOffset => (int)_callout->start_match;
-        public int CurrentOffset => (int)_callout->current_position;
-        public int MaxCapture => (int)_callout->capture_top;
-        public int LastCapture => (int)_callout->capture_last;
-        public int PatternPosition => (int)_callout->pattern_position;
+        public readonly int StartOffset => (int)_callout->start_match;
+        public readonly int CurrentOffset => (int)_callout->current_position;
+        public readonly int MaxCapture => (int)_callout->capture_top;
+        public readonly int LastCapture => (int)_callout->capture_last;
+        public readonly int PatternPosition => (int)_callout->pattern_position;
 
-        public int NextPatternItemLength => (int)_callout->next_item_length;
-        public int StringOffset => Info.StringOffset;
-        public string String => Info.String;
+        public readonly int NextPatternItemLength => (int)_callout->next_item_length;
+        public readonly int StringOffset => Info.StringOffset;
+        public readonly string String => Info.String;
 
-        public PcreCalloutInfo Info => _info ??= _regex.GetCalloutInfoByPatternPosition(PatternPosition);
+        public readonly PcreCalloutInfo Info => _regex.GetCalloutInfoByPatternPosition(PatternPosition);
 
-        public bool StartMatch => (_callout->callout_flags & PcreConstants.CALLOUT_STARTMATCH) != 0;
-        public bool Backtrack => (_callout->callout_flags & PcreConstants.CALLOUT_BACKTRACK) != 0;
+        public readonly bool StartMatch => (_callout->callout_flags & PcreConstants.CALLOUT_STARTMATCH) != 0;
+        public readonly bool Backtrack => (_callout->callout_flags & PcreConstants.CALLOUT_BACKTRACK) != 0;
     }
 }

--- a/src/PCRE.NET/PcreRefGroup.cs
+++ b/src/PCRE.NET/PcreRefGroup.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace PCRE
+{
+    public ref struct PcreRefGroup
+    {
+        private readonly ReadOnlySpan<char> _subject;
+
+        internal PcreRefGroup(ReadOnlySpan<char> subject, int startOffset, int endOffset)
+        {
+            _subject = subject;
+            Index = startOffset;
+            EndIndex = endOffset;
+        }
+
+        public int Index { get; }
+        public int EndIndex { get; }
+
+        public int Length => EndIndex > Index ? EndIndex - Index : 0;
+
+        public ReadOnlySpan<char> Value => _subject.Slice(Index, Length);
+
+        public bool Success => _subject != default;
+
+        public static implicit operator string(PcreRefGroup group) => group.Value.ToString();
+
+        public override string ToString() => Value.ToString();
+    }
+}

--- a/src/PCRE.NET/PcreRefGroup.cs
+++ b/src/PCRE.NET/PcreRefGroup.cs
@@ -8,6 +8,8 @@ namespace PCRE
     {
         private readonly ReadOnlySpan<char> _subject;
 
+        public delegate T Func<out T>(PcreRefGroup group);
+
         internal PcreRefGroup(ReadOnlySpan<char> subject, int startOffset, int endOffset)
         {
             _subject = subject;

--- a/src/PCRE.NET/PcreRefGroup.cs
+++ b/src/PCRE.NET/PcreRefGroup.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace PCRE
 {
+    [DebuggerTypeProxy(typeof(DebugProxy))]
     public ref struct PcreRefGroup
     {
         private readonly ReadOnlySpan<char> _subject;
@@ -18,12 +20,26 @@ namespace PCRE
 
         public int Length => EndIndex > Index ? EndIndex - Index : 0;
 
-        public ReadOnlySpan<char> Value => _subject.Slice(Index, Length);
+        public ReadOnlySpan<char> Value => Index < 0 ? default : _subject.Slice(Index, Length);
 
-        public bool Success => _subject != default;
+        public bool Success => _subject != default && Index >= 0;
 
         public static implicit operator string(PcreRefGroup group) => group.Value.ToString();
 
         public override string ToString() => Value.ToString();
+
+        internal class DebugProxy
+        {
+            public bool Success { get; }
+            public string Value { get; }
+
+            public DebugProxy(PcreRefGroup group)
+            {
+                Success = group.Success;
+                Value = Success ? group.Value.ToString() : null;
+            }
+
+            public override string ToString() => Value ?? "<no match>";
+        }
     }
 }

--- a/src/PCRE.NET/PcreRefGroup.cs
+++ b/src/PCRE.NET/PcreRefGroup.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace PCRE
 {
     [DebuggerTypeProxy(typeof(DebugProxy))]
-    public ref struct PcreRefGroup
+    public readonly ref struct PcreRefGroup
     {
         private readonly ReadOnlySpan<char> _subject;
 

--- a/src/PCRE.NET/PcreRefMatch.cs
+++ b/src/PCRE.NET/PcreRefMatch.cs
@@ -10,13 +10,13 @@ namespace PCRE
     public unsafe ref struct PcreRefMatch
     {
         private readonly InternalRegex _regex;
-        private readonly uint[] _oVector;
+        private readonly ReadOnlySpan<uint> _oVector;
         private int _resultCode;
         private char* _markPtr;
 
         public delegate T Func<out T>(PcreRefMatch match);
 
-        internal PcreRefMatch(InternalRegex regex, uint[] oVector)
+        internal PcreRefMatch(InternalRegex regex, ReadOnlySpan<uint> oVector)
         {
             // Empty match
 
@@ -28,7 +28,7 @@ namespace PCRE
             _resultCode = 0;
         }
 
-        internal PcreRefMatch(ReadOnlySpan<char> subject, InternalRegex regex, uint[] oVector, char* mark)
+        internal PcreRefMatch(ReadOnlySpan<char> subject, InternalRegex regex, ReadOnlySpan<uint> oVector, char* mark)
         {
             // Callout
 
@@ -47,8 +47,8 @@ namespace PCRE
         public readonly PcreRefGroup this[string name] => GetGroup(name);
 
         internal ReadOnlySpan<char> Subject { get; private set; }
-        internal uint[] OutputVector => _oVector;
-        internal bool IsInitialized => _regex != null;
+        internal readonly ReadOnlySpan<uint> OutputVector => _oVector;
+        internal readonly bool IsInitialized => _regex != null;
 
         public readonly int Index => this[0].Index;
 
@@ -135,13 +135,13 @@ namespace PCRE
             return new DuplicateNamedGroupEnumerable(this, indexes);
         }
 
-        internal void FirstMatch(ReadOnlySpan<char> subject, PcreMatchSettings settings)
+        internal void FirstMatch(ReadOnlySpan<char> subject, PcreMatchSettings settings, int startIndex)
         {
             _regex.Match(
                 ref this,
                 subject,
                 settings,
-                settings.StartIndex,
+                startIndex,
                 settings.AdditionalOptions.ToPatternOptions()
             );
         }

--- a/src/PCRE.NET/PcreRefMatch.cs
+++ b/src/PCRE.NET/PcreRefMatch.cs
@@ -40,25 +40,25 @@ namespace PCRE
             _resultCode = oVector.Length / 2;
         }
 
-        public int CaptureCount => _regex?.CaptureCount ?? 0;
+        public readonly int CaptureCount => _regex?.CaptureCount ?? 0;
 
-        public PcreRefGroup this[int index] => GetGroup(index);
+        public readonly PcreRefGroup this[int index] => GetGroup(index);
 
-        public PcreRefGroup this[string name] => GetGroup(name);
+        public readonly PcreRefGroup this[string name] => GetGroup(name);
 
         internal ReadOnlySpan<char> Subject { get; }
 
-        public int Index => this[0].Index;
+        public readonly int Index => this[0].Index;
 
-        public int EndIndex => this[0].EndIndex;
+        public readonly int EndIndex => this[0].EndIndex;
 
-        public int Length => this[0].Length;
+        public readonly int Length => this[0].Length;
 
-        public ReadOnlySpan<char> Value => this[0].Value;
+        public readonly ReadOnlySpan<char> Value => this[0].Value;
 
-        public bool Success => _resultCode > 0;
+        public readonly bool Success => _resultCode > 0;
 
-        public ReadOnlySpan<char> Mark
+        public readonly ReadOnlySpan<char> Mark
         {
             get
             {
@@ -74,13 +74,13 @@ namespace PCRE
             }
         }
 
-        public GroupList Groups => new GroupList(this);
+        public readonly GroupList Groups => new GroupList(this);
 
-        public bool IsPartialMatch => _resultCode == PcreConstants.ERROR_PARTIAL;
+        public readonly bool IsPartialMatch => _resultCode == PcreConstants.ERROR_PARTIAL;
 
-        public GroupEnumerator GetEnumerator() => new GroupEnumerator(this);
+        public readonly GroupEnumerator GetEnumerator() => new GroupEnumerator(this);
 
-        private PcreRefGroup GetGroup(int index)
+        private readonly PcreRefGroup GetGroup(int index)
         {
             if (index < 0 || index > CaptureCount)
                 return default;
@@ -99,7 +99,7 @@ namespace PCRE
             return new PcreRefGroup(Subject, startOffset, endOffset);
         }
 
-        private PcreRefGroup GetGroup(string name)
+        private readonly PcreRefGroup GetGroup(string name)
         {
             var map = _regex?.CaptureNames;
             if (map == null)
@@ -121,7 +121,7 @@ namespace PCRE
             return default;
         }
 
-        public DuplicateNamedGroupEnumerable GetDuplicateNamedGroups(string name)
+        public readonly DuplicateNamedGroupEnumerable GetDuplicateNamedGroups(string name)
         {
             var map = _regex?.CaptureNames;
             if (map == null)
@@ -147,14 +147,14 @@ namespace PCRE
             );
         }
 
-        private int GetStartOfNextMatchIndex()
+        private readonly int GetStartOfNextMatchIndex()
         {
             // It's possible to have EndIndex < Index
             // when the pattern contains \K in a lookahead
             return Math.Max(Index, EndIndex);
         }
 
-        public override string ToString() => Value.ToString();
+        public override readonly string ToString() => Value.ToString();
 
         public readonly ref struct GroupList
         {

--- a/src/PCRE.NET/PcreRefMatch.cs
+++ b/src/PCRE.NET/PcreRefMatch.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using PCRE.Internal;
 
 namespace PCRE
 {
+    [DebuggerTypeProxy(typeof(DebugProxy))]
     public unsafe ref struct PcreRefMatch
     {
         private readonly InternalRegex _regex;
@@ -147,6 +150,25 @@ namespace PCRE
 
             public bool MoveNext()
                 => ++_index <= _match.CaptureCount;
+        }
+
+        [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+        internal class DebugProxy
+        {
+            public bool Success { get; }
+            public string Value { get; }
+
+            public PcreRefGroup.DebugProxy[] Groups { get; }
+
+            public DebugProxy(PcreRefMatch match)
+            {
+                Success = match.Success;
+                Value = Success ? match.Value.ToString() : null;
+
+                Groups = new PcreRefGroup.DebugProxy[match.CaptureCount + 1];
+                for (var i = 0; i <= match.CaptureCount; ++i)
+                    Groups[i] = new PcreRefGroup.DebugProxy(match[i]);
+            }
         }
     }
 }

--- a/src/PCRE.NET/PcreRefMatch.cs
+++ b/src/PCRE.NET/PcreRefMatch.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-using JetBrains.Annotations;
 using PCRE.Internal;
 
 namespace PCRE
@@ -27,6 +23,18 @@ namespace PCRE
             _markPtr = result.mark;
 
             _resultCode = result.result_code;
+        }
+
+        internal PcreRefMatch(ReadOnlySpan<char> subject, InternalRegex regex, uint[] oVector, char* mark)
+        {
+            // Callout
+
+            Subject = subject;
+            _regex = regex;
+            _oVector = oVector;
+            _markPtr = mark;
+
+            _resultCode = oVector.Length / 2;
         }
 
         public int CaptureCount => _regex.CaptureCount;

--- a/src/PCRE.NET/PcreRefMatch.cs
+++ b/src/PCRE.NET/PcreRefMatch.cs
@@ -47,7 +47,6 @@ namespace PCRE
         public PcreRefGroup this[string name] => GetGroup(name);
 
         internal ReadOnlySpan<char> Subject { get; }
-        internal uint[] OVector => _oVector;
 
         public int Index => this[0].Index;
 
@@ -139,9 +138,10 @@ namespace PCRE
             if (!Success)
                 return;
 
-            this = _regex.NextMatch(
-                this,
+            this = _regex.Match(
+                Subject,
                 settings,
+                _oVector,
                 GetStartOfNextMatchIndex(),
                 settings.AdditionalOptions.ToPatternOptions() | PcreConstants.NO_UTF_CHECK | (Length == 0 ? PcreConstants.NOTEMPTY_ATSTART : 0)
             );

--- a/src/PCRE.NET/PcreRefMatch.cs
+++ b/src/PCRE.NET/PcreRefMatch.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using JetBrains.Annotations;
+using PCRE.Internal;
+
+namespace PCRE
+{
+    public unsafe ref struct PcreRefMatch
+    {
+        private readonly InternalRegex _regex;
+        private readonly int _resultCode;
+        private readonly uint[] _oVector;
+        private readonly char* _markPtr;
+
+        internal PcreRefMatch(ReadOnlySpan<char> subject, InternalRegex regex, ref Native.match_result result, uint[] oVector)
+        {
+            // Real match
+
+            Subject = subject;
+            _regex = regex;
+            _oVector = oVector;
+            _markPtr = result.mark;
+
+            _resultCode = result.result_code;
+        }
+
+        public int CaptureCount => _regex.CaptureCount;
+
+        public PcreRefGroup this[int index] => GetGroup(index);
+
+        public PcreRefGroup this[string name] => GetGroup(name);
+
+        internal ReadOnlySpan<char> Subject { get; }
+
+        public int Index => this[0].Index;
+
+        public int EndIndex => this[0].EndIndex;
+
+        public int Length => this[0].Length;
+
+        public ReadOnlySpan<char> Value => this[0].Value;
+
+        public bool Success => _resultCode > 0;
+
+        public ReadOnlySpan<char> Mark
+        {
+            get
+            {
+                if (_markPtr == null)
+                    return default;
+
+                char* markEnd;
+                for (markEnd = _markPtr; *markEnd != 0; ++markEnd)
+                {
+                }
+
+                return new ReadOnlySpan<char>(_markPtr, (int)(markEnd - _markPtr));
+            }
+        }
+
+        public bool IsPartialMatch => _resultCode == PcreConstants.ERROR_PARTIAL;
+
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        private PcreRefGroup GetGroup(int index)
+        {
+            if (index < 0 || index > CaptureCount)
+                return default;
+
+            var isAvailable = index < _resultCode || IsPartialMatch && index == 0;
+            if (!isAvailable)
+                return default;
+
+            index *= 2;
+            if (index >= _oVector.Length)
+                return default;
+
+            var startOffset = (int)_oVector[index];
+            var endOffset = (int)_oVector[index + 1];
+
+            return new PcreRefGroup(Subject, startOffset, endOffset);
+        }
+
+        private PcreRefGroup GetGroup(string name)
+        {
+            var map = _regex.CaptureNames;
+            if (map == null)
+                return default;
+
+            if (!map.TryGetValue(name, out var indexes))
+                return default;
+
+            if (indexes.Length == 1)
+                return GetGroup(indexes[0]);
+
+            foreach (var index in indexes)
+            {
+                var group = GetGroup(index);
+                if (group.Success)
+                    return group;
+            }
+
+            return default;
+        }
+
+        // TODO
+        // public IEnumerable<PcreGroup> GetDuplicateNamedGroups(string name)
+        // {
+        //     var map = _regex.CaptureNames;
+        //     if (map == null)
+        //         yield break;
+        //
+        //     if (!map.TryGetValue(name, out var indexes))
+        //         yield break;
+        //
+        //     foreach (var index in indexes)
+        //     {
+        //         var group = GetGroup(index);
+        //         if (group != null)
+        //             yield return group;
+        //     }
+        // }
+
+        internal int GetStartOfNextMatchIndex()
+        {
+            // It's possible to have EndIndex < Index
+            // when the pattern contains \K in a lookahead
+            return Math.Max(Index, EndIndex);
+        }
+
+        public override string ToString() => Value.ToString();
+
+        public ref struct Enumerator
+        {
+            private readonly PcreRefMatch _match;
+            private int _index;
+
+            internal Enumerator(PcreRefMatch match)
+            {
+                _match = match;
+                _index = -1;
+            }
+
+            public PcreRefGroup Current => _match[_index];
+
+            public bool MoveNext()
+                => ++_index <= _match.CaptureCount;
+        }
+    }
+}

--- a/src/PCRE.NET/PcreRegex.Match.cs
+++ b/src/PCRE.NET/PcreRegex.Match.cs
@@ -278,14 +278,16 @@ namespace PCRE
                     return false;
 
                 if (!_match.Success)
-                    return Match(_settings.StartIndex, 0);
+                {
+                    _match = _regex.Match(_subject, _settings, _settings.StartIndex, _settings.AdditionalOptions.ToPatternOptions());
+                    if (_match.Success)
+                        return true;
 
-                return Match(_match.GetStartOfNextMatchIndex(), PcreConstants.NO_UTF_CHECK | (_match.Length == 0 ? PcreConstants.NOTEMPTY_ATSTART : 0));
-            }
+                    _regex = null;
+                    return false;
+                }
 
-            private bool Match(int startIndex, uint additionalOptions)
-            {
-                _match = _regex.Match(_subject, _settings, startIndex, _settings.AdditionalOptions.ToPatternOptions() | additionalOptions);
+                _match.NextMatch(_settings);
                 if (_match.Success)
                     return true;
 

--- a/src/PCRE.NET/PcreRegex.Match.cs
+++ b/src/PCRE.NET/PcreRegex.Match.cs
@@ -105,7 +105,7 @@ namespace PCRE
             if (settings.StartIndex < 0 || settings.StartIndex > subject.Length)
                 throw new IndexOutOfRangeException("Invalid StartIndex value");
 
-            return InternalRegex.Match(subject, settings, settings.StartIndex, settings.AdditionalOptions.ToPatternOptions());
+            return InternalRegex.Match(subject, settings, InternalRegex.CreateNfaOVector(), settings.StartIndex, settings.AdditionalOptions.ToPatternOptions());
         }
 
         [Pure]
@@ -279,7 +279,7 @@ namespace PCRE
 
                 if (!_match.Success)
                 {
-                    _match = _regex.Match(_subject, _settings, _settings.StartIndex, _settings.AdditionalOptions.ToPatternOptions());
+                    _match = _regex.Match(_subject, _settings, _regex.CreateNfaOVector(), _settings.StartIndex, _settings.AdditionalOptions.ToPatternOptions());
                     if (_match.Success)
                         return true;
 

--- a/src/PCRE.NET/PcreRegex.Match.cs
+++ b/src/PCRE.NET/PcreRegex.Match.cs
@@ -105,7 +105,10 @@ namespace PCRE
             if (settings.StartIndex < 0 || settings.StartIndex > subject.Length)
                 throw new IndexOutOfRangeException("Invalid StartIndex value");
 
-            return InternalRegex.Match(subject, settings, InternalRegex.CreateNfaOVector(), settings.StartIndex, settings.AdditionalOptions.ToPatternOptions());
+            var match = InternalRegex.CreateRefMatch();
+            match.FirstMatch(subject, settings);
+
+            return match;
         }
 
         [Pure]
@@ -277,17 +280,16 @@ namespace PCRE
                 if (_regex == null)
                     return false;
 
-                if (!_match.Success)
+                if (!_match.IsInitialized)
                 {
-                    _match = _regex.Match(_subject, _settings, _regex.CreateNfaOVector(), _settings.StartIndex, _settings.AdditionalOptions.ToPatternOptions());
-                    if (_match.Success)
-                        return true;
-
-                    _regex = null;
-                    return false;
+                    _match = _regex.CreateRefMatch();
+                    _match.FirstMatch(_subject, _settings);
+                }
+                else
+                {
+                    _match.NextMatch(_settings);
                 }
 
-                _match.NextMatch(_settings);
                 if (_match.Success)
                     return true;
 

--- a/src/PCRE.NET/PcreRegex.Match.cs
+++ b/src/PCRE.NET/PcreRegex.Match.cs
@@ -62,25 +62,25 @@ namespace PCRE
         public PcreMatch Match(string subject, Func<PcreCallout, PcreCalloutResult> onCallout)
             => Match(subject, 0, PcreMatchOptions.None, onCallout);
 
-        public PcreRefMatch Match(ReadOnlySpan<char> subject, Func<PcreCallout, PcreCalloutResult> onCallout)
+        public PcreRefMatch Match(ReadOnlySpan<char> subject, PcreRefCalloutFunc onCallout)
             => Match(subject, 0, PcreMatchOptions.None, onCallout);
 
         public PcreMatch Match(string subject, PcreMatchOptions options, Func<PcreCallout, PcreCalloutResult> onCallout)
             => Match(subject, 0, options, onCallout);
 
-        public PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchOptions options, Func<PcreCallout, PcreCalloutResult> onCallout)
+        public PcreRefMatch Match(ReadOnlySpan<char> subject, PcreMatchOptions options, PcreRefCalloutFunc onCallout)
             => Match(subject, 0, options, onCallout);
 
         public PcreMatch Match(string subject, int startIndex, Func<PcreCallout, PcreCalloutResult> onCallout)
             => Match(subject, startIndex, PcreMatchOptions.None, onCallout);
 
-        public PcreRefMatch Match(ReadOnlySpan<char> subject, int startIndex, Func<PcreCallout, PcreCalloutResult> onCallout)
+        public PcreRefMatch Match(ReadOnlySpan<char> subject, int startIndex, PcreRefCalloutFunc onCallout)
             => Match(subject, startIndex, PcreMatchOptions.None, onCallout);
 
         public PcreMatch Match(string subject, int startIndex, PcreMatchOptions options, Func<PcreCallout, PcreCalloutResult> onCallout)
             => Match(subject, PcreMatchSettings.GetSettings(startIndex, options, onCallout));
 
-        public PcreRefMatch Match(ReadOnlySpan<char> subject, int startIndex, PcreMatchOptions options, Func<PcreCallout, PcreCalloutResult> onCallout)
+        public PcreRefMatch Match(ReadOnlySpan<char> subject, int startIndex, PcreMatchOptions options, PcreRefCalloutFunc onCallout)
             => Match(subject, PcreMatchSettings.GetSettings(startIndex, options, onCallout));
 
         public PcreMatch Match(string subject, PcreMatchSettings settings)
@@ -134,7 +134,7 @@ namespace PCRE
         }
 
         [Pure]
-        public RefMatchEnumerator Matches(ReadOnlySpan<char> subject, int startIndex, Func<PcreCallout, PcreCalloutResult> onCallout)
+        public RefMatchEnumerator Matches(ReadOnlySpan<char> subject, int startIndex, PcreRefCalloutFunc onCallout)
         {
             if (subject == null)
                 throw new ArgumentNullException(nameof(subject));


### PR DESCRIPTION
This defines a different match API based on `ref struct` types.

Closes #18 
