### PR TITLE
Remove C++ dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(PCRE.NET.Native)
+project(PCRE.NET.Native C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -51,10 +51,10 @@ add_library(PCRE.NET.Native SHARED
         PCRE/src/pcre2_valid_utf.c
         PCRE/src/pcre2_xclass.c
         PCRE.NET.Native/pcrenet.h
-        PCRE.NET.Native/pcrenet_compile.cpp
-        PCRE.NET.Native/pcrenet_convert.cpp
-        PCRE.NET.Native/pcrenet_info.cpp
-        PCRE.NET.Native/pcrenet_match.cpp
+        PCRE.NET.Native/pcrenet_compile.c
+        PCRE.NET.Native/pcrenet_convert.c
+        PCRE.NET.Native/pcrenet_info.c
+        PCRE.NET.Native/pcrenet_match.c
 )
 
 add_compile_definitions(

--- a/src/PCRE.NET.Native/PCRE.NET.Native.vcxproj
+++ b/src/PCRE.NET.Native/PCRE.NET.Native.vcxproj
@@ -45,10 +45,10 @@
     <ClCompile Include="..\PCRE\src\pcre2_ucd.c" />
     <ClCompile Include="..\PCRE\src\pcre2_valid_utf.c" />
     <ClCompile Include="..\PCRE\src\pcre2_xclass.c" />
-    <ClCompile Include="pcrenet_compile.cpp" />
-    <ClCompile Include="pcrenet_convert.cpp" />
-    <ClCompile Include="pcrenet_match.cpp" />
-    <ClCompile Include="pcrenet_info.cpp" />
+    <ClCompile Include="pcrenet_compile.c" />
+    <ClCompile Include="pcrenet_convert.c" />
+    <ClCompile Include="pcrenet_match.c" />
+    <ClCompile Include="pcrenet_info.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\PCRE\src\config.h" />

--- a/src/PCRE.NET.Native/PCRE.NET.Native.vcxproj.filters
+++ b/src/PCRE.NET.Native/PCRE.NET.Native.vcxproj.filters
@@ -94,19 +94,19 @@
     <ClCompile Include="..\PCRE\src\pcre2_valid_utf.c">
       <Filter>PCRE\Sources</Filter>
     </ClCompile>
-    <ClCompile Include="pcrenet_compile.cpp">
+    <ClCompile Include="pcrenet_compile.c">
       <Filter>PCRE.NET\Sources</Filter>
     </ClCompile>
     <ClCompile Include="..\PCRE\src\pcre2_substring.c">
       <Filter>PCRE\Sources</Filter>
     </ClCompile>
-    <ClCompile Include="pcrenet_match.cpp">
+    <ClCompile Include="pcrenet_match.c">
       <Filter>PCRE.NET\Sources</Filter>
     </ClCompile>
-    <ClCompile Include="pcrenet_info.cpp">
+    <ClCompile Include="pcrenet_info.c">
       <Filter>PCRE.NET\Sources</Filter>
     </ClCompile>
-    <ClCompile Include="pcrenet_convert.cpp">
+    <ClCompile Include="pcrenet_convert.c">
       <Filter>PCRE.NET\Sources</Filter>
     </ClCompile>
     <ClCompile Include="..\PCRE\src\pcre2_script_run.c">

--- a/src/PCRE.NET.Native/pcrenet.h
+++ b/src/PCRE.NET.Native/pcrenet.h
@@ -1,12 +1,25 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
+#include <assert.h>
 
 #include "../PCRE/src/config.h"
 #include "../PCRE/src/pcre2.h"
 
 #if __GNUC__
-#   define PCRENET_EXPORT(type, name) extern "C" __attribute__((visibility("default"))) type pcrenet_##name
+#   define PCRENET_EXPORT(type, name) __attribute__((visibility("default"))) type pcrenet_##name
 #else
-#   define PCRENET_EXPORT(type, name) extern "C" __declspec(dllexport) type __cdecl pcrenet_##name
+#   define PCRENET_EXPORT(type, name) __declspec(dllexport) type __cdecl pcrenet_##name
+#endif
+
+#ifndef __has_extension
+#define __has_extension(...) 0
+#endif
+
+#ifdef static_assert
+#define c_static_assert(e, msg) static_assert((e), msg)
+#elif __has_extension(c_static_assert)
+#define c_static_assert(e, msg) _Static_assert((e), msg)
+#else
+#define c_static_assert(e, msg) typedef char __c_static_assert__[(e)?1:-1]
 #endif

--- a/src/PCRE.NET.Native/pcrenet_compile.c
+++ b/src/PCRE.NET.Native/pcrenet_compile.c
@@ -1,7 +1,7 @@
 
 #include "pcrenet.h"
 
-static_assert(sizeof(uint32_t) <= sizeof(PCRE2_SIZE), "Parameter size must fit into PCRE2_SIZE");
+c_static_assert(sizeof(uint32_t) <= sizeof(PCRE2_SIZE), "Parameter size must fit into PCRE2_SIZE");
 
 typedef struct
 {
@@ -29,14 +29,14 @@ typedef struct
 
 PCRENET_EXPORT(void, compile)(const pcrenet_compile_input* input, pcrenet_compile_result* result)
 {
-    const auto context = pcre2_compile_context_create(nullptr);
+    pcre2_compile_context* context = pcre2_compile_context_create(NULL);
 
     if (input->new_line)
         pcre2_set_newline(context, input->new_line);
-    
+
     if (input->bsr)
         pcre2_set_bsr(context, input->bsr);
-    
+
     if (input->parens_nest_limit)
         pcre2_set_parens_nest_limit(context, input->parens_nest_limit);
 

--- a/src/PCRE.NET.Native/pcrenet_convert.c
+++ b/src/PCRE.NET.Native/pcrenet_convert.c
@@ -18,15 +18,15 @@ typedef struct
 
 PCRENET_EXPORT(int32_t, convert)(convert_input* input, convert_result* result)
 {
-    const auto context = pcre2_convert_context_create(nullptr);
+    pcre2_convert_context* context = pcre2_convert_context_create(NULL);
 
     pcre2_set_glob_escape(context, input->glob_escape);
     pcre2_set_glob_separator(context, input->glob_separator);
 
-    PCRE2_UCHAR* buffer = nullptr;
+    PCRE2_UCHAR* buffer = NULL;
     PCRE2_SIZE bufferLength = 0;
 
-    const auto errorCode = pcre2_pattern_convert(
+    const int errorCode = pcre2_pattern_convert(
         input->pattern,
         input->pattern_length,
         input->options,

--- a/src/PCRE.NET.Native/pcrenet_info.c
+++ b/src/PCRE.NET.Native/pcrenet_info.c
@@ -18,7 +18,7 @@ PCRENET_EXPORT(int32_t, config)(uint32_t key, void* data)
 
 static int get_callout_count_handler(pcre2_callout_enumerate_block* block, void* data)
 {
-    const auto count = static_cast<uint32_t*>(data);
+    uint32_t* count = (uint32_t*)data;
     ++*count;
     return 0;
 }
@@ -32,7 +32,7 @@ PCRENET_EXPORT(uint32_t, get_callout_count)(pcre2_code* code)
 
 static int get_callouts_handler(pcre2_callout_enumerate_block* block, void* data)
 {
-    const auto blocks = static_cast<pcre2_callout_enumerate_block**>(data);
+    pcre2_callout_enumerate_block** blocks = (pcre2_callout_enumerate_block**)data;
     **blocks = *block;
     ++*blocks;
     return 0;
@@ -45,7 +45,7 @@ PCRENET_EXPORT(void, get_callouts)(pcre2_code* code, pcre2_callout_enumerate_blo
 
 PCRENET_EXPORT(pcre2_jit_stack*, jit_stack_create)(uint32_t startSize, uint32_t maxSize)
 {
-    return pcre2_jit_stack_create(startSize, maxSize, nullptr);
+    return pcre2_jit_stack_create(startSize, maxSize, NULL);
 }
 
 PCRENET_EXPORT(void, jit_stack_free)(pcre2_jit_stack* stack)


### PR DESCRIPTION
The dependency graph of `PCRE.NET.Native.so` looks like this:

```sh
$ ldd -r src/cmake-x64/PCRE.NET.Native.so

        linux-vdso.so.1 (0x00007fff57bf1000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f78e9bad000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f78e9995000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f78e95a4000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f78e9206000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f78ea1c7000)
```

Since we are not using any major C++ feature (exception handling, RAII etc.) in this slim wrapper, we can shave off the dependency on libstdc++.

With plain C in PR branch, it becomes:

```sh
$ ldd -r src/cmake-x64/PCRE.NET.Native.so

        linux-vdso.so.1 (0x00007ffcff338000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f8897686000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f8897d08000)
```